### PR TITLE
Support custom domain name

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -21,13 +21,14 @@ $ terraform init
 
 There are various variables to configure The Things Join Server deployment. The most important variables:
 
-| Name              | Description                                      | Default           |
-| ----------------- | ------------------------------------------------ | ----------------- |
-| `region`          | AWS region                                       | `eu-west-1`       |
-| `public_url`      | Public URL that is mapped to the API Gateway URL | Default stage URL |
-| `release_channel` | Version to deploy: `stable` or `snapshot`        | `stable`          |
-| `networks`        | LoRaWAN Network Servers                          | none              |
-| `applications`    | LoRaWAN Application Servers                      | none              |
+| Name              | Description                               | Default                               |
+| ----------------- | ----------------------------------------- | ------------------------------------- |
+| `region`          | AWS region                                | `eu-west-1`                           |
+| `domain`          | Custom domain name                        | none                                  |
+| `public_url`      | Public URL                                | `https://<domain>` or API Gateway URL |
+| `release_channel` | Version to deploy: `stable` or `snapshot` | `stable`                              |
+| `networks`        | LoRaWAN Network Servers                   | none                                  |
+| `applications`    | LoRaWAN Application Servers               | none                                  |
 
 Besides these variables, you can configure the resource prefixes and AWS IoT Core Thing Type name to keep multiple deployments of The Things Join Server in the same AWS account apart. It is recommended to use different AWS accounts for different The Things Join Server deployments.
 
@@ -36,6 +37,16 @@ For convenience, you can start your custom configuration from the example config
 ```bash
 $ cp example.tfvars custom.tfvars
 ```
+
+### Optional: Custom domain name
+
+Use the `domain` variable to use a custom domain name, like `join.example.com`.
+
+When using a custom domain, a certificate with AWS Certificate Manager (ACM) will be requested. This certificate uses DNS validation for proof of ownership of the domain name. During the deployment process, you have 45 minutes to verify the ownership of the domain name by creating a CNAME record for the DNS validation. [See DNS validation documentation](https://docs.aws.amazon.com/acm/latest/userguide/dns-validation.html).
+
+After you have deployed The Things Join Server with a custom domain name, create a DNS CNAME record for your domain with the Terraform output value `domain_target`.
+
+If you do not configure a custom domain, the public AWS API Gateway invocation URL will be used.
 
 ### Optional: Networks and Applications
 
@@ -69,7 +80,7 @@ $ terraform output -raw root_provisioner_password
 
 Get started with [`ttjs` CLI](https://www.npmjs.com/package/ttjs-cli) to manage The Things Join Server. When you run `ttjs init`, use the following settings:
 
-- **Server URL**: Terraform output `api_url`
+- **Server URL**: Terraform output `url`
 - **Configure Provisioner**: on
 - **Provisioner username**: `root`
 - **Provisioner password**: Terraform output `root_provisioner_password`

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -1,0 +1,32 @@
+resource "aws_acm_certificate" "domain" {
+  count             = var.domain == "" ? 0 : 1
+  domain_name       = var.domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_apigatewayv2_domain_name" "domain" {
+  count       = var.domain == "" ? 0 : 1
+  domain_name = var.domain
+
+  domain_name_configuration {
+    certificate_arn = aws_acm_certificate_validation.domain[0].certificate_arn
+    endpoint_type   = "REGIONAL"
+    security_policy = "TLS_1_2"
+  }
+}
+
+resource "aws_apigatewayv2_api_mapping" "domain" {
+  count       = var.domain == "" ? 0 : 1
+  api_id      = aws_apigatewayv2_api.api.id
+  domain_name = aws_apigatewayv2_domain_name.domain[0].id
+  stage       = aws_apigatewayv2_stage.api.id
+}
+
+resource "aws_acm_certificate_validation" "domain" {
+  count           = var.domain == "" ? 0 : 1
+  certificate_arn = aws_acm_certificate.domain[0].arn
+}

--- a/terraform/example.tfvars
+++ b/terraform/example.tfvars
@@ -1,5 +1,8 @@
 ## AWS region
-region = "us-east-1"
+# region = "us-east-1"
+
+## Custom domain name
+# domain = "join.example.com"
 
 ## Uncomment to use the snapshot release of The Things Join Server.
 # release_channel = "snapshot"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,7 @@ locals {
   claiming_function          = "${var.resource_prefix}-claiming"
   clients_function           = "${var.resource_prefix}-clients"
 
-  public_url = coalesce(var.public_url, trimsuffix(aws_apigatewayv2_stage.api.invoke_url, "/"))
+  public_url = var.domain == "" ? trimsuffix(aws_apigatewayv2_stage.api.invoke_url, "/") : "https://${var.domain}"
 
   function_environment = {
     JS_SSM_PARAMETER_PREFIX    = "/${var.ssm_parameter_prefix}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -43,9 +43,9 @@ output "clients_function" {
   value       = local.clients_function
 }
 
-output "api_url" {
-  description = "The Things Join Server API Gateway URL"
-  value       = aws_apigatewayv2_stage.api.invoke_url
+output "url" {
+  description = "The Things Join Server URL"
+  value       = local.public_url
 }
 
 output "openapi_url" {
@@ -57,4 +57,9 @@ output "root_provisioner_password" {
   description = "Root Provisioner password"
   sensitive   = true
   value       = random_password.root_provisioner_password.result
+}
+
+output "domain_target" {
+  description = "Target name to configure as DNS CNAME record of your domain"
+  value       = var.domain != "" ? aws_apigatewayv2_domain_name.domain[0].domain_name_configuration[0].target_domain_name : ""
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "region" {
   default = "eu-west-1"
 }
 
-variable "public_url" {
+variable "domain" {
   type    = string
   default = ""
 }


### PR DESCRIPTION
This adds support for a custom domain name, including an AWS Certificate Manager certificate request and documentation.